### PR TITLE
Don't fail empty builds

### DIFF
--- a/.github/workflows/generate-authorized-keys.yml
+++ b/.github/workflows/generate-authorized-keys.yml
@@ -56,8 +56,12 @@ jobs:
           done
       - name: "Commit updated authorized_keys"
         run: |
-          git config --global user.email "developers@stormbit.net"
-          git config --global user.name "StormBit KeyFace"
-          git add authorized_keys
-          git commit -m "Updating authorized_keys"
-          git push
+          if git status --porcelain --untracked-files=no | grep .; then
+            git config --global user.email "developers@stormbit.net"
+            git config --global user.name "StormBit KeyFace"
+            git add authorized_keys
+            git commit -m "Updating authorized_keys"
+            git push
+          else
+              echo "Nothing to update!"
+          fi


### PR DESCRIPTION
# What?
Wrap the Git commands in the final step in a conditional to check if there are any updated files

# Why?
So that builds only fail when something is _wrong_.